### PR TITLE
Fix missing Exception in except clause (Windows)

### DIFF
--- a/spyderlib/utils/iofuncs.py
+++ b/spyderlib/utils/iofuncs.py
@@ -331,7 +331,7 @@ def load_dictionary(filename):
             # Old format (Spyder 2.0-2.1 for Python 2)
             with open(pickle_filename, 'U') as fdesc:
                 data = pickle.loads(fdesc.read())
-        except (pickle.PickleError, TypeError):
+        except (pickle.PickleError, TypeError, UnicodeDecodeError):
             # New format (Spyder >=2.2 for Python 2 and Python 3)
             with open(pickle_filename, 'rb') as fdesc:
                 data = pickle.loads(fdesc.read())


### PR DESCRIPTION
This fixes an issue - on Windows - in the Variable Explorer while trying to load data saved earlier as a .spydata file.
At least on Windows, pickle can raise a UnicodeDecodeError when the new format file is opened without mode='wb'. This was not caught (only pickle.PickleError and TypeError would be caught) and resulted in the failure of the loading of the data.
